### PR TITLE
Fix grecaptcha.render is not a function

### DIFF
--- a/view/frontend/web/js/reCaptcha.js
+++ b/view/frontend/web/js/reCaptcha.js
@@ -170,7 +170,7 @@ define(
 
                 if (this.getIsVisible()) {
                     var initCaptchaInterval = setInterval(function () {
-                        if (window.grecaptcha) {
+                        if (window.grecaptcha && window.grecaptcha.render) {
                             clearInterval(initCaptchaInterval);
                             me.initCaptcha();
                         }


### PR DESCRIPTION
Moved: https://github.com/magespecialist/m2-MSP_ReCaptcha/pull/37
Fixes: https://github.com/magespecialist/m2-MSP_ReCaptcha/issues/36

Google initializes the grecaptcha object with only the ready function at first. The remaining functions, including render and execute, are added to the object at a later point. Thus, the interval check for just the object is insufficient and introduces a race condition. Adding a check for the render function itself resolves this.