### PR TITLE
Fixed issue of reCaptcha missing on contact page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "php": "^5.6|^7.0|^7.1|^7.2",
         "magento/magento-composer-installer": "*",
-        "google/recaptcha": "^1.1"
+        "google/recaptcha": "^1.1",
+        "magento/module-captcha":"*"
     },
     "suggest": {
         "msp/security-suite": "Full MageSpecialist Security Suite"


### PR DESCRIPTION
Fixed issue of  reCaptcha missing on contact page

Description (*)
This pull request resolved issue of Google reCaptcha doesn't display on contact form of magento2.

Fixed Issues (if relevant)
#21 : reCaptcha missing on contact page