### PR TITLE
Add support for ReCaptcha in newsletter

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -47,6 +47,7 @@ class Config
     const XML_PATH_ENABLED_FRONTEND_FORGOT = 'msp_securitysuite_recaptcha/frontend/enabled_forgot';
     const XML_PATH_ENABLED_FRONTEND_CONTACT = 'msp_securitysuite_recaptcha/frontend/enabled_contact';
     const XML_PATH_ENABLED_FRONTEND_CREATE = 'msp_securitysuite_recaptcha/frontend/enabled_create';
+    const XML_PATH_ENABLED_FRONTEND_NEWSLETTER = 'msp_securitysuite_recaptcha/frontend/enabled_newsletter';
 
     /**
      * @var ScopeConfigInterface
@@ -165,6 +166,19 @@ class Config
         }
 
         return (bool) $this->scopeConfig->getValue(static::XML_PATH_ENABLED_FRONTEND_CREATE);
+    }
+
+    /**
+     * Return true if enabled on frontend newsletter
+     * @return bool
+     */
+    public function isEnabledFrontendNewsletter()
+    {
+        if (!$this->isEnabledFrontend()) {
+            return false;
+        }
+
+        return (bool) $this->scopeConfig->getValue(static::XML_PATH_ENABLED_FRONTEND_NEWSLETTER);
     }
 
     /**

--- a/Model/LayoutSettings.php
+++ b/Model/LayoutSettings.php
@@ -55,6 +55,7 @@ class LayoutSettings
                 'create' => $this->config->isEnabledFrontendCreate(),
                 'forgot' => $this->config->isEnabledFrontendForgot(),
                 'contact' => $this->config->isEnabledFrontendContact(),
+                'newsletter' => $this->config->isEnabledFrontendNewsletter(),
             ]
         ];
     }

--- a/Model/Provider/Failure/RedirectUrl/ReferrerUrlProvider.php
+++ b/Model/Provider/Failure/RedirectUrl/ReferrerUrlProvider.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * MageSpecialist
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to info@magespecialist.it so we can send you a copy immediately.
+ *
+ * @category   MSP
+ * @package    MSP_ReCaptcha
+ * @copyright  Copyright (c) 2017 Skeeller srl (http://www.magespecialist.it)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace MSP\ReCaptcha\Model\Provider\Failure\RedirectUrl;
+
+use Magento\Framework\App\Response\RedirectInterface;
+use MSP\ReCaptcha\Model\Provider\Failure\RedirectUrlProviderInterface;
+
+/**
+ * Class ReferrerUrlProvider
+ *
+ * @package MSP\ReCaptcha\Model\Provider\Failure\RedirectUrl
+ */
+class ReferrerUrlProvider implements RedirectUrlProviderInterface
+{
+
+    /**
+     * @var \Magento\Framework\App\Response\RedirectInterface
+     */
+    private $redirect;
+
+    /**
+     * ReferrerUrlProvider constructor.
+     *
+     * @param \Magento\Framework\App\Response\RedirectInterface $redirect
+     */
+    public function __construct(
+        RedirectInterface $redirect
+    ) {
+        $this->redirect = $redirect;
+    }
+
+    /**
+     * Get redirection URL
+     *
+     * @return string
+     */
+    public function execute()
+    {
+        return $this->redirect->getRefererUrl();
+    }
+}

--- a/Plugin/Block/Frontend/ReCaptchaPlugin.php
+++ b/Plugin/Block/Frontend/ReCaptchaPlugin.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * MageSpecialist
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to info@magespecialist.it so we can send you a copy immediately.
+ *
+ * @category   MSP
+ * @package    MSP_ReCaptcha
+ * @copyright  Copyright (c) 2017 Skeeller srl (http://www.magespecialist.it)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace MSP\ReCaptcha\Plugin\Block\Frontend;
+
+use Magento\Framework\Serialize\Serializer\Json as Serializer;
+
+/**
+ * Class ReCaptchaPlugin
+ *
+ * @package MSP\ReCaptcha\Plugin\Block\Frontend
+ */
+class ReCaptchaPlugin
+{
+
+    /**
+     * @var \Magento\Framework\Serialize\Serializer\Json
+     */
+    private $serializer;
+
+    /**
+     * ReCaptchaPlugin constructor.
+     *
+     * @param \Magento\Framework\Serialize\Serializer\Json $serializer
+     */
+    public function __construct(
+        Serializer $serializer
+    ) {
+        $this->serializer = $serializer;
+    }
+
+    /**
+     * @param $subject \MSP\ReCaptcha\Block\Frontend\ReCaptcha
+     * @param $result
+     *
+     * @return bool|string
+     */
+    public function afterGetJsLayout($subject, $result)
+    {
+        $recaptchaId = $subject->getReCaptchaId();
+
+        $ogJsLayout = $this->serializer->unserialize($result);
+        $ogConfig = $ogJsLayout['components'][$recaptchaId];
+
+        $newJsLayout = $subject->getData('jsLayout');
+        $newConfig = $newJsLayout['components']['msp-recaptcha'];
+
+        $ogJsLayout['components'][$recaptchaId] = array_replace_recursive($ogConfig, $newConfig);
+
+        return $this->serializer->serialize($ogJsLayout);
+    }
+}

--- a/Plugin/Block/SubscribePlugin.php
+++ b/Plugin/Block/SubscribePlugin.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * MageSpecialist
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to info@magespecialist.it so we can send you a copy immediately.
+ *
+ * @category   MSP
+ * @package    MSP_ReCaptcha
+ * @copyright  Copyright (c) 2017 Skeeller srl (http://www.magespecialist.it)
+ * @license    http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace MSP\ReCaptcha\Plugin\Block;
+
+use DOMDocument;
+use DOMNode;
+
+/**
+ * Class SubscribePlugin
+ *
+ * @package MSP\ReCaptcha\Plugin\Block
+ */
+class SubscribePlugin
+{
+    /**
+     * @param \Magento\Newsletter\Block\Subscribe $subject
+     * @param $result
+     *
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return string
+     */
+    public function afterToHtml($subject, $result) {
+        $block = $subject->getLayout()->getBlock('msp-recaptcha-newsletter');
+        
+        if (!$block) {
+            return $result;
+        }
+        
+        $blockHtml = $block->toHtml();
+        
+        $subscribeBlockContent = new DOMDocument();
+        $subscribeBlockContent->loadHTML($result);
+
+        $recaptchaContent = new DOMDocument();
+        $recaptchaContent->loadHTML($blockHtml);
+
+        $form = $subscribeBlockContent->getElementsByTagName('form');
+        $formNodes = [];
+
+        if ($form) {
+            foreach ($form as $formNode) {
+                $formNodes[] = $formNode;
+            }
+
+            foreach ($recaptchaContent->getElementsByTagName('body')->item(0)->childNodes as $recaptchaChildNode) {
+                $recaptchaChildNode = $subscribeBlockContent->importNode($recaptchaChildNode, true);
+                
+                if ($formNodes) {
+                    $formNodes[0]->appendChild($recaptchaChildNode);
+                }
+            }
+
+            return $subscribeBlockContent->saveHTML();
+        }
+
+        return $result;
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -160,6 +160,14 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="enabled_newsletter" translate="label" type="select" sortOrder="240" showInDefault="1"
+                       showInWebsite="1" showInStore="0" canRestore="1">
+                    <label>Use in Newsletter</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -39,6 +39,7 @@
                 <enabled_forgot>1</enabled_forgot>
                 <enabled_contact>1</enabled_contact>
                 <enabled_create>1</enabled_create>
+                <enabled_newsletter>1</enabled_newsletter>
             </frontend>
         </msp_securitysuite_recaptcha>
     </default>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -175,4 +175,41 @@
         <plugin sortOrder="1" name="mSPReCaptchaAuthenticationPopup"
                 type="MSP\ReCaptcha\Plugin\Block\Account\AuthenticationPopupPlugin"/>
     </type>
+
+    <!-- Newsletter -->
+    <virtualType name="MSP\ReCaptcha\Model\Provider\IsCheckRequired\Frontend\Newsletter"
+                 type="MSP\ReCaptcha\Model\IsCheckRequired">
+        <arguments>
+            <argument name="enableConfigFlag"
+                      xsi:type="string">msp_securitysuite_recaptcha/frontend/enabled_newsletter</argument>
+            <argument name="area" xsi:type="string">frontend</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="MSP\ReCaptcha\Model\Provider\Failure\NewsletterObserver"
+                 type="MSP\ReCaptcha\Model\Provider\Failure\ObserverRedirectFailure">
+        <arguments>
+            <argument name="redirectUrlProvider"
+                      xsi:type="object">MSP\ReCaptcha\Model\Provider\Failure\RedirectUrl\ReferrerUrlProvider</argument>
+        </arguments>
+    </virtualType>
+    <virtualType name="MSP\ReCaptcha\Observer\Frontend\NewsletterObserver"
+                 type="MSP\ReCaptcha\Observer\ReCaptchaObserver">
+        <arguments>
+            <argument name="isCheckRequired"
+                      xsi:type="object">MSP\ReCaptcha\Model\Provider\IsCheckRequired\Frontend\Newsletter</argument>
+            <argument name="responseProvider"
+                      xsi:type="object">MSP\ReCaptcha\Model\Provider\Response\DefaultResponseProvider</argument>
+            <argument name="failureProvider"
+                      xsi:type="object">MSP\ReCaptcha\Model\Provider\Failure\NewsletterObserver</argument>
+        </arguments>
+    </virtualType>
+    <type name="Magento\Newsletter\Block\Subscribe">
+        <plugin sortOrder="1" name="MSPReCaptchaSubscribe"
+                type="MSP\ReCaptcha\Plugin\Block\SubscribePlugin"/>
+    </type>
+
+    <type name="MSP\ReCaptcha\Block\Frontend\ReCaptcha">
+        <plugin sortOrder="1" name="MSPReCaptchaBlockFrontendReCaptchaPlugin"
+                type="MSP\ReCaptcha\Plugin\Block\Frontend\ReCaptchaPlugin"/>
+    </type>
 </config>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -37,4 +37,7 @@
     <event name="controller_action_predispatch_contact_index_post">
         <observer name="msp_captcha" instance="MSP\ReCaptcha\Observer\Frontend\ContactFormObserver" />
     </event>
+    <event name="controller_action_predispatch_newsletter_subscriber_new">
+        <observer name="msp_captcha" instance="MSP\ReCaptcha\Observer\Frontend\NewsletterObserver" />
+    </event>
 </config>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -43,5 +43,24 @@
                 </argument>
             </arguments>
         </referenceBlock>
+        <referenceBlock name="form.subscribe">
+            <block class="MSP\ReCaptcha\Block\Frontend\ReCaptcha" name="msp-recaptcha-newsletter" after="-" template="MSP_ReCaptcha::msp_recaptcha.phtml">
+                <arguments>
+                    <argument name="jsLayout" xsi:type="array">
+                        <item name="components" xsi:type="array">
+                            <item name="msp-recaptcha" xsi:type="array">
+                                <item name="component" xsi:type="string">MSP_ReCaptcha/js/reCaptcha</item>
+                                <item name="reCaptchaId" xsi:type="string">msp-recaptcha-newsletter</item>
+                                <item name="zone" xsi:type="string">newsletter</item>
+                                <item name="badge" xsi:type="string">bottomright</item>
+                                <item name="settings" xsi:type="array">
+                                    <item name="size" xsi:type="string">invisible</item>
+                                </item>
+                            </item>
+                        </item>
+                    </argument>
+                </arguments>
+            </block>
+        </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
This pull request adds support for ReCaptcha validation in the newsletter subscribe blocks. Some notes on the implementation:

In order to resolve layout issues with the ReCaptcha displaying in the footer, I've configured the newsletter ReCaptcha instance to display as invisible in the bottom right position by default via configuration specified in the layout xml. 

Additionally, in order to add the ReCaptcha block to the subscribe.phtml template without a direct template override, and due to the template not providing a child block container, I added a plugin to the afterToHtml method in the Subscribe block to dynamically append the ReCaptcha element to the form. 

This pull request should be blocked by the pull request to fix the issue with multiple ReCaptcha instances as I make use of the dynamic ID methods added to the ReCaptcha block class in the pull.

https://github.com/magento/magespecialist_ReCaptcha/pull/22