### PR TITLE
Temporary fix for issue #21 - reCaptcha missing on contact page

### DIFF
--- a/Block/Frontend/ReCaptcha.php
+++ b/Block/Frontend/ReCaptcha.php
@@ -81,7 +81,7 @@ class ReCaptcha extends Template
             $layout['components']['msp-recaptcha']['settings'] = $this->layoutSettings->getCaptchaSettings();
         }
         
-        if(isset($layout['components']['msp-recaptcha']) && !$this->config->isEnabledFrontend()) {
+        if (isset($layout['components']['msp-recaptcha']) && !$this->config->isEnabledFrontend()) {
             unset($layout['components']['msp-recaptcha']);
         }
 

--- a/view/frontend/layout/contact_index_index.xml
+++ b/view/frontend/layout/contact_index_index.xml
@@ -26,6 +26,7 @@
         <referenceContainer name="form.additional.info">
             <block class="MSP\ReCaptcha\Block\Frontend\ReCaptcha" name="msp-recaptcha" after="-"
                    template="MSP_ReCaptcha::msp_recaptcha.phtml"
+                   cacheable="false"
                    ifconfig="msp_securitysuite_recaptcha/frontend/enabled">
 
                 <arguments>

--- a/view/frontend/web/js/reCaptcha.js
+++ b/view/frontend/web/js/reCaptcha.js
@@ -85,10 +85,7 @@ define(
              * @returns {Boolean}
              */
             getIsInvisibleRecaptcha: function () {
-                if (this.settings.size !== 'invisible') {
-                    return true;
-                }
-                return false;
+                return this.settings.size !== 'invisible';
             },
 
             /**
@@ -182,7 +179,6 @@ define(
                 if (this.settings.size !== 'invisible') {
                     return $(document).find('input[type=checkbox].required-captcha').prop( "checked", state );
                 }
-                return;
             },
 
             /**


### PR DESCRIPTION
FIX for issue https://github.com/magento/magespecialist_ReCaptcha/issues/21 .
Magento tries to reload the form decalred as `$this->_isScopePrivate` in `\Magento\Contact\Block\ContactForm` line 25.

While rendering the content, the reCaptcha is not initialized.