### PR TITLE
Do not load ReCaptcha block if disabled

### DIFF
--- a/Block/Frontend/ReCaptcha.php
+++ b/Block/Frontend/ReCaptcha.php
@@ -104,4 +104,16 @@ class ReCaptcha extends Template
 
         return Json::encode($layout);
     }
+    
+    /**
+     * @return string
+     */
+    public function toHtml()
+    {
+        if (!$this->config->isEnabledFrontend()) {
+            return '';
+        }
+
+        return parent::toHtml();
+    }
 }


### PR DESCRIPTION
In a fresh Magento 2.3.2 environment, ReCaptcha is enabled by default. However, in the Store Configuration, the setting **Enable** is set to its default value *No* and the **Google API Website Key** and **Google API Secret Key** are empty. Because of this, Recaptcha shouldn't work. However, the Block is still delivering output, loading JavaScript files that are actually not doing anything, decreasing performance for no reason. This can be replayed simply by installing a fresh Magento 2.3 instance with the Recaptcha module enabled but not configured.

This PR simply goes back the basics. If the settings are pointing towards that ReCaptcha can not be used, the Block should not deliver any output either.

This PR automatically fixes the following issue as well: https://github.com/magento/magespecialist_ReCaptcha/issues/11 

Additionally, once this PR is done, we can clean up the `getJsLayout` method in the same Block, to remove the `if ($this->config->isEnabledFrontend()) {}` (but keep its body, obviously) because `getJsLayout()` will never be called when the Block delivers no output.