### PR TITLE
Add missing dependency Magento_Config to module.xml

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -23,6 +23,7 @@
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="MSP_ReCaptcha" setup_version="1.5.0">
         <sequence>
+            <module name="Magento_Config"/>
             <module name="Magento_Customer"/>
             <module name="Magento_Checkout"/>
             <module name="Magento_Newsletter"/>


### PR DESCRIPTION
I'm trying to run integration tests with the Recaptcha module installed, but it fails due to a missing `Magento_Config` dependency in module.xml.

Error:
```
[Zend_Db_Statement_Exception]
SQLSTATE[42S02]: Base table or view not found: 1146 
Table 'mage_integration_tests.core_config_data' doesn't exist, 
query was: SELECT `main_table`.* FROM `core_config_data` AS `main_table`
```

Adding `Magento_Config` to the module sequence fixes this.
