### PR TITLE
Fix js error - cannot read property 'nodeName' of undefined.

### DIFF
--- a/view/frontend/web/js/reCaptcha.js
+++ b/view/frontend/web/js/reCaptcha.js
@@ -130,6 +130,12 @@ define(
                 $reCaptcha.attr('id', this.getReCaptchaId());
 
                 $parentForm = $wrapper.parents('form');
+
+                if ($parentForm.length === 0) {
+                    // Form element not found.
+                    return;
+                }
+
                 me = this;
 
                 // eslint-disable-next-line no-undef


### PR DESCRIPTION
This JS error occurs when newsletter subscription removed on frontend. Or is missing on somepages. For example, custom Magento theme removed newsletter block from footer. And shows it only at homepage or contacts page. In such case, this error will occur at all other pages.