### PR TITLE
MC-31540: Google Recaptcha missing for virtual product orders

### DIFF
--- a/Block/LayoutProcessor/Checkout/Onepage.php
+++ b/Block/LayoutProcessor/Checkout/Onepage.php
@@ -61,20 +61,26 @@ class Onepage implements LayoutProcessorInterface
     {
         if ($this->config->isEnabledFrontend()) {
             $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
-                ['shippingAddress']['children']['customer-email']['children']
-                ['msp_recaptcha']['settings'] = $this->layoutSettings->getCaptchaSettings();
+            ['shippingAddress']['children']['customer-email']['children']
+            ['msp_recaptcha']['settings'] = $this->layoutSettings->getCaptchaSettings();
+
+            $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+            ['payment']['children']['customer-email']['children']
+            ['msp_recaptcha']['settings'] = $this->layoutSettings->getCaptchaSettings();
 
             $jsLayout['components']['checkout']['children']['authentication']['children']
-                ['msp_recaptcha']['settings'] = $this->layoutSettings->getCaptchaSettings();
-        }
-
-        if (!$this->config->isEnabledFrontend()) {
+            ['msp_recaptcha']['settings'] = $this->layoutSettings->getCaptchaSettings();
+        } else {
             if (isset($jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
                 ['shippingAddress']['children']['customer-email']['children']['msp_recaptcha'])) {
                 unset($jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
                     ['shippingAddress']['children']['customer-email']['children']['msp_recaptcha']);
             }
-
+            if (isset($jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+                ['payment']['children']['customer-email']['children']['msp_recaptcha'])) {
+                unset($jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+                    ['payment']['children']['customer-email']['children']['msp_recaptcha']);
+            }
             if (isset($jsLayout['components']['checkout']['children']['authentication']['children']['msp_recaptcha'])) {
                 unset($jsLayout['components']['checkout']['children']['authentication']['children']['msp_recaptcha']);
             }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "msp/recaptcha",
-    "version": "2.2.2",
+    "version": "2.2.3",
     "description": "Google reCaptcha integration for Magento2",
     "require": {
         "php": "^7.1|^7.2|^7.3",

--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -50,6 +50,25 @@
                                                 </item>
                                             </item>
                                         </item>
+                                        <item name="billing-step" xsi:type="array">
+                                            <item name="children" xsi:type="array">
+                                                <item name="payment" xsi:type="array">
+                                                    <item name="children" xsi:type="array">
+                                                        <item name="customer-email" xsi:type="array">
+                                                            <item name="children" xsi:type="array">
+                                                                <item name="msp_recaptcha" xsi:type="array">
+                                                                    <item name="component" xsi:type="string">MSP_ReCaptcha/js/reCaptcha</item>
+                                                                    <item name="displayArea" xsi:type="string">additional-login-form-fields</item>
+                                                                    <item name="configSource" xsi:type="string">checkoutConfig</item>
+                                                                    <item name="reCaptchaId" xsi:type="string">msp-recaptcha-checkout-inline-login-billing</item>
+                                                                    <item name="zone" xsi:type="string">login</item>
+                                                                </item>
+                                                            </item>
+                                                        </item>
+                                                    </item>
+                                                </item>
+                                            </item>
+                                        </item>
                                     </item>
                                 </item>
 


### PR DESCRIPTION
Fix for the issue [MC-31540](https://jira.corp.magento.com/browse/MC-31540)

Builds:
https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/30181/
Semantic-Version-Checker-UR failures are not related to this fix, failures only relate to the Inventory component. Re-run results of the failed Functional EE tests are below.

https://m2build-ur.devops.magento.com/job/All-User-Requested-Tests/30189/